### PR TITLE
Use base-orphans to import Foldable ((,) a) instance

### DIFF
--- a/infernu.cabal
+++ b/infernu.cabal
@@ -72,7 +72,7 @@ library
                      , Infernu.Unify
                      , Infernu.Util
   -- TODO: use only mtl (not transformers)
-  build-depends:       base >= 4.6 && < 5, mtl, containers, transformers, either, language-ecmascript, digits, parsec, fgl, optparse-applicative
+  build-depends:       base >= 4.6 && < 5, base-orphans, mtl, containers, transformers, either, language-ecmascript, digits, parsec, fgl, optparse-applicative
   default-language:    Haskell2010
   ghc-options: -Wall -O2 -rtsopts -threaded
   if flag(debug)

--- a/src/Infernu/Prelude.hs
+++ b/src/Infernu/Prelude.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | The sole purpose of this module is to fix pre/post ghc 7.10 compatibility issues
 module Infernu.Prelude 
@@ -20,6 +19,7 @@ module Infernu.Prelude
   )
 where
 
+import Data.Orphans ()
  
 #if MIN_VERSION_base(4,8,0)
 import Prelude
@@ -36,11 +36,6 @@ import Prelude hiding (foldl, foldl1, foldr1, foldr, mapM, sequence)
 #if MIN_VERSION_base(4,7,0)
 import Data.Bool (bool)
 #else
-
-instance Foldable ((,) a) where
-    foldMap f (_, y) = f y
-
-    foldr f z (_, y) = f y z
 
 bool :: a -> a -> Bool -> a
 bool f _ False = f


### PR DESCRIPTION
Currently, `infernu` defines an orphan `Foldable ((,) a` instance. However, there are a number of other packages that also define this instance, including [`semigroupoids`](https://github.com/ekmett/semigroupoids/blob/99ce7a18876da749c49e8ee969ff03a340fb76af/src/Data/Traversable/Instances.hs#L36-56) and [`lens`](https://github.com/ekmett/lens/blob/7af45fb03374ef23a3658c17e692ea475f6bf585/src/Control/Lens/Internal/Instances.hs#L44-70), which means that if anyone were to use any combination of these libraries together on GHC 7.6 or earlier, it could lead to instance conflicts.

To help mitigate this possibility, this pull request imports this instance from the `base-orphans` library (which exports backported instances introduced in later versions of `base`, including the aforementioned one). This way, we can keep all of these orphan instances in one package so that `infernu`, `semigroupoids`, `lens`, etc. can coexist.
